### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -94,6 +94,22 @@ env/
 */*/*.swp
 */*/*/*.swp
 
+# pyspades specific
+pyspades/bytes.cpp
+pyspades/common.cpp
+pyspades/contained.cpp
+pyspades/loaders.cpp
+pyspades/mapmaker.cpp
+pyspades/packet.cpp
+pyspades/vxl.cpp
+pyspades/world.cpp
+enet/enet.c
+
+# native binaries directories
+build/
+enet/build/
+
+
 # Misc
 .github
 .gitattributes

--- a/.dockerignore
+++ b/.dockerignore
@@ -105,6 +105,27 @@ pyspades/vxl.cpp
 pyspades/world.cpp
 enet/enet.c
 
+# C extensions
+*.so
+
+# C++ extension
+
+*.slo
+*.lo
+*.o
+
+*.so
+*.dylib
+
+*.lai
+*.la
+*.a
+
+# py2exe
+py2exe/dist/
+py2exe/*.zip
+
+
 # native binaries directories
 build/
 enet/build/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
+### A general python module specific ###
 # Git
 .git
 .gitignore
+.github
+.gitattributes
 
 # CI
 .codeclimate.yml
@@ -11,17 +14,8 @@ docker-compose.yml
 .docker
 
 # Byte-compiled / optimized / DLL files
-__pycache__/
-*/__pycache__/
-*/*/__pycache__/
-*/*/*/__pycache__/
-*.py[cod]
-*/*.py[cod]
-*/*/*.py[cod]
-*/*/*/*.py[cod]
-
-# C extensions
-*.so
+**/__pycache__/
+**/.py[cod]
 
 # Distribution / packaging
 .Python
@@ -61,11 +55,11 @@ coverage.xml
 *,cover
 
 # Translations
-*.mo
-*.pot
+**/*.mo
+**/*.pot
 
 # Django stuff:
-*.log
+**/*.log
 
 # Sphinx documentation
 docs/_build/
@@ -75,26 +69,21 @@ target/
 
 # Virtual environment
 .env/
+env/
 .venv/
 venv/
-env/
 
 # PyCharm
 .idea
 
 # Python mode for VIM
-.ropeproject
-*/.ropeproject
-*/*/.ropeproject
-*/*/*/.ropeproject
+**/.ropeproject
 
 # Vim swap files
-*.swp
-*/*.swp
-*/*/*.swp
-*/*/*/*.swp
+**/*.swp
 
-# pyspades specific
+
+### pyspades specific ###
 pyspades/bytes.cpp
 pyspades/common.cpp
 pyspades/contained.cpp
@@ -106,34 +95,30 @@ pyspades/world.cpp
 enet/enet.c
 
 # C extensions
-*.so
+**/*.so
 
 # C++ extension
+**/*.slo
+**/*.lo
+**/*.o
 
-*.slo
-*.lo
-*.o
+**/*.so
+**/*.dylib
 
-*.so
-*.dylib
-
-*.lai
-*.la
-*.a
+**/*.lai
+**/*.la
+**/*.a
 
 # py2exe
 py2exe/dist/
 py2exe/*.zip
-
 
 # native binaries directories
 build/
 enet/build/
 
 
-# Misc
-.github
-.gitattributes
+### Misc ###
 README.md
 Dockerfile
 db.sqlite3

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,102 @@
+# Git
+.git
+.gitignore
+
+# CI
+.codeclimate.yml
+.travis.yml
+
+# Docker
+docker-compose.yml
+.docker
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*/__pycache__/
+*/*/__pycache__/
+*/*/*/__pycache__/
+*.py[cod]
+*/*.py[cod]
+*/*/*.py[cod]
+*/*/*/*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage.*
+.coverage
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Virtual environment
+.env/
+.venv/
+venv/
+env/
+
+# PyCharm
+.idea
+
+# Python mode for VIM
+.ropeproject
+*/.ropeproject
+*/*/.ropeproject
+*/*/*/.ropeproject
+
+# Vim swap files
+*.swp
+*/*.swp
+*/*/*.swp
+*/*/*/*.swp
+
+# Misc
+.github
+.gitattributes
+README.md
+Dockerfile
+db.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ RUN apk add --no-cache --virtual .build-deps-cython gcc musl-dev \
 # TODO: while this behaviour suits production envs perfectly, make a dev env option
 COPY pyspades/ /usr/src/app/pyspades/
 COPY enet/ /usr/src/app/enet/
-COPY build.py build.sh COPYING.txt CREDITS.txt LICENSE /usr/src/app/
+COPY build.py build.sh build_all.sh COPYING.txt CREDITS.txt LICENSE /usr/src/app/
 
 RUN apk add --no-cache --virtual .build-deps-server gcc musl-dev g++ \
-    && STDCPP_STATIC=1 ./build.sh \
+    && STDCPP_STATIC=1 ./build_all.sh \
     && apk del .build-deps-server 
 
 # Copy over the rest and default to launching the server

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:2.7-alpine
 
-RUN mkdir -p /usr/src/app
-RUN mkdir -p /usr/src/app/enet
-RUN mkdir -p /usr/src/app/pyspades
+RUN mkdir -p /usr/src/app && mkdir -p /usr/src/app/enet && mkdir -p /usr/src/app/pyspades
 WORKDIR /usr/src/app
 
 # Installing dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM python:2.7-alpine
+
+RUN mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/app/enet
+RUN mkdir -p /usr/src/app/pyspades
+WORKDIR /usr/src/app
+
+# Installing dependencies.
+# In order to keep layers lean we instantly remove the build essentials 
+COPY requirements.txt /usr/src/app/
+
+RUN apk add --no-cache --virtual .build-deps-cython gcc musl-dev \
+    && apk add --no-cache --virtual .build-deps-pillow zlib-dev jpeg-dev \
+    \
+    && pip install --no-cache-dir -r requirements.txt \
+    && apk del .build-deps-cython \
+    && apk del .build-deps-pillow
+
+# The fact that we removed gcc beforehand makes us download it again
+# This is remedied by building the server core first and leaving all .py scripts 
+# to the last. A change in python script won't trigger downloading gcc all over again
+# but a change in .pyx or .c file will.
+# TODO: while this behaviour suits production envs perfectly, make a dev env option
+COPY pyspades/ /usr/src/app/pyspades/
+COPY enet/ /usr/src/app/enet/
+COPY build.py build.sh COPYING.txt CREDITS.txt LICENSE /usr/src/app/
+
+RUN apk add --no-cache --virtual .build-deps-server gcc musl-dev g++ \
+    && STDCPP_STATIC=1 ./build.sh \
+    && apk del .build-deps-server 
+
+# Copy over the rest and default to launching the server
+COPY . /usr/src/app
+CMD ./run_server.sh
+
+EXPOSE 32887/udp 32887 32886 32885

--- a/build.py
+++ b/build.py
@@ -18,7 +18,7 @@ names = [
 ]
 
 for name in names:
-    extra = {'extra_compile_args' : ['-std=c++11']} if name in ['pyspades.vxl', 'pyspades.world', 'pyspades.mapmaker'] else {}
+    extra = {'extra_compile_args' : ['-std=c++11', '-static-libstdc++', '-static-libgcc']} if name in ['pyspades.vxl', 'pyspades.world', 'pyspades.mapmaker'] else {}
 
     ext_modules.append(Extension(name, ['./%s.pyx' % name.replace('.', '/')],
         language = 'c++', include_dirs=['./pyspades'], **extra))

--- a/build.py
+++ b/build.py
@@ -17,7 +17,7 @@ names = [
     'pyspades.loaders',
     'pyspades.mapmaker'
 ]
-static = os.environ['STDCPP_STATIC'] == "1"
+static = os.environ.get('STDCPP_STATIC') == "1"
 
 if static:
     print "Linking the build statically."

--- a/build.py
+++ b/build.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
@@ -16,9 +17,19 @@ names = [
     'pyspades.loaders',
     'pyspades.mapmaker'
 ]
+static = os.environ['STDCPP_STATIC'] == "1"
+
+if static:
+    print "Linking the build statically."
 
 for name in names:
-    extra = {'extra_compile_args' : ['-std=c++11', '-static-libstdc++', '-static-libgcc']} if name in ['pyspades.vxl', 'pyspades.world', 'pyspades.mapmaker'] else {}
+    if static:
+        extra = {'extra_link_args' : ['-static-libstdc++', '-static-libgcc']}  
+    else:
+        extra = {}
+
+    if name in ['pyspades.vxl', 'pyspades.world', 'pyspades.mapmaker']:
+        extra["extra_compile_args"] = ['-std=c++11']
 
     ext_modules.append(Extension(name, ['./%s.pyx' % name.replace('.', '/')],
         language = 'c++', include_dirs=['./pyspades'], **extra))

--- a/build_all.sh
+++ b/build_all.sh
@@ -7,7 +7,7 @@ if [ -d "venv/" ] && [ ! "x$(command -v python)" == "x$VIRTUAL_ENV/bin/python" ]
 fi
 
 # any compiled file whatsoever
-
+# TODO: exclude rules are complicated. Invert to make includes more excplicit and defined by directory.
 find . -type f \( \
 	-name '*.py[cod]' -o -name '*.slo' -o -name '*.lo' -o -name '*.o' \
 	-o -name '*.so' -o -name '*.dylib' -o -name '*.lai' -o -name '*.la' \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Cython>=0.25.2,<0.26
+Twisted>=16.6.0,<16.7
+Jinja2>=2.8,<2.9
+Pillow>=3.4.2,<3.5
+pygeoip>=0.3.2,<0.4
+pycrypto>=2.6.1,<2.7
+pyasn1>=0.1.9,<0.2
+zope.interface>=4.3.3,<4.4


### PR DESCRIPTION
Using `python:2.7-alpine` base which is built on top of alpine linux. Targeted towards production deployments.

The total image size after a build on clean repo is
```
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
spades-server       latest              e22412d8d7b7        2 minutes ago       190 MB
```

Some notes:
1. Statically linked libstdc++ so that there's no overhead of extra alpine packages is kept. Maybe there is no so much overhead in terms of size, but semantically feels more right to not depend on extra dynamic libraries in runtime apart from python modules.
2. Adding to `CREDITS` will invalidate pyspades build cache on next docker image build. Not a big deal I guess because not happens often and people will invalidate their cache by other means all the time.
3. `gcc` and `musl-dev` are downloaded twice during docker image build, which increases the build time but generates leaner docker layers (which is better for production set ups and generally pushing to docker hub).

Usage:
1. Make changes of your wish to config and user scripts. (or don't do them at all, the server runs from fresh build just fine)
2. Bake it into image: `docker build -t spades-server .` 
3. Run an instance: `docker run -dP --name spades-server-1 spades-server`
4. Find the mapped ports of the instance: `docker port spades-server-1`
5. Connect to `aos://127.0.0.1:PORT` and enjoy

Future notes:
- Development version which will have fatter layers but less build time and build overhead. Probably this is the job for debian because generally it's a more dev "friendly" distro.
- Make an official image and push it to the [hub.docker.com](http://hub.docker.com)?